### PR TITLE
Adding ipv6 support to ltm node and virtual server

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -135,7 +135,7 @@ func resourceBigipLtmNodeCreate(d *schema.ResourceData, meta interface{}) error 
 	description := d.Get("description").(string)
 	ratio := d.Get("ratio").(int)
 
-	r, _ := regexp.Compile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:.*)$")
+	r, _ := regexp.Compile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:[^%]*)$")
 
 	log.Println("[INFO] Creating node " + name + "::" + address)
 	var err error
@@ -206,7 +206,8 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	} else {
 		// xxx.xxx.xxx.xxx(%x)
-		regex := regexp.MustCompile(`((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?`)
+		// x:x(%x)
+		regex := regexp.MustCompile(`((?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:.*:[^%]*))(?:\%\d+)?`)
 		address := regex.FindStringSubmatch(node.Address)
 		log.Println("[INFO] Address: " + address[1])
 		if err := d.Set("address", node.Address); err != nil {
@@ -258,7 +259,7 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	name := d.Id()
 	address := d.Get("address").(string)
-	r, _ := regexp.Compile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:.*)$")
+	r, _ := regexp.Compile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:[^%]*)$")
 
 	var node *bigip.Node
 	if r.MatchString(address) {

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var TEST_NODE_NAME = fmt.Sprintf("/%s/test-node", TEST_PARTITION)
+var TEST_V6_NODE_NAME = fmt.Sprintf("/%s/test-v6-node", TEST_PARTITION)
 var TEST_FQDN_NODE_NAME = fmt.Sprintf("/%s/test-fqdn-node", TEST_PARTITION)
 
 var TEST_NODE_RESOURCE = `
@@ -30,6 +31,19 @@ resource "bigip_ltm_node" "test-node" {
 	ratio = "91"
 }
 `
+
+var TEST_V6_NODE_RESOURCE = `
+resource "bigip_ltm_node" "test-node" {
+	name = "` + TEST_V6_NODE_NAME + `"
+	address = "fe80::10"
+	connection_limit = "0"
+	dynamic_ratio = "1"
+	monitor = "default"
+	rate_limit = "disabled"
+	state = "user-up"
+}
+`
+
 var TEST_FQDN_NODE_RESOURCE = `
 resource "bigip_ltm_node" "test-fqdn-node" {
 	name = "` + TEST_FQDN_NODE_NAME + `"
@@ -69,6 +83,31 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 			},
 		},
 	})
+
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckNodesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_V6_NODE_RESOURCE,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(TEST_V6_NODE_NAME, true),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "name", TEST_V6_NODE_NAME),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "address", "fe80::10"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "connection_limit", "0"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "dynamic_ratio", "1"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "monitor", "default"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "rate_limit", "disabled"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "state", "user-up"),
+				),
+			},
+		},
+	})
+
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -116,6 +155,26 @@ func TestAccBigipLtmNode_import(t *testing.T) {
 			},
 		},
 	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckNodesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_V6_NODE_RESOURCE,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckNodeExists(TEST_V6_NODE_NAME, true),
+				),
+				ResourceName:      TEST_V6_NODE_NAME,
+				ImportState:       false,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -84,7 +84,6 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 		},
 	})
 
-
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAcctPreCheck(t)
@@ -107,7 +106,6 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 			},
 		},
 	})
-
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -174,7 +172,6 @@ func TestAccBigipLtmNode_import(t *testing.T) {
 			},
 		},
 	})
-
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -44,8 +44,8 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 			},
 
 			"source": {
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				//Default:     "0.0.0.0/0",
 				Computed:    true,
 				Description: "Source IP and mask for the virtual server",
@@ -75,8 +75,8 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 			},
 
 			"mask": {
-				Type:        schema.TypeString,
-				Optional:    true,
+				Type:     schema.TypeString,
+				Optional: true,
 				//Default:     "255.255.255.255",
 				Computed:    true,
 				Description: "subnet mask",
@@ -270,15 +270,15 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 	vs_dest := vs.Destination
 	if strings.Count(vs_dest, ":") >= 2 {
 		regex := regexp.MustCompile(`^(\/.+\/)(.*:[^%]*)(?:\%\d+)?(?:\.(\d+))$`)
-                destination := regex.FindStringSubmatch(vs.Destination)
-                if destination == nil {
-                        return fmt.Errorf("Unable to extract destination address and port from virtual server destination: " + vs.Destination)
-                }
+		destination := regex.FindStringSubmatch(vs.Destination)
+		if destination == nil {
+			return fmt.Errorf("Unable to extract destination address and port from virtual server destination: " + vs.Destination)
+		}
 		if err := d.Set("destination", destination[2]); err != nil {
-		       return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
-           }
-       }
-       if strings.Count(vs_dest, ":") < 2 {
+			return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
+		}
+	}
+	if strings.Count(vs_dest, ":") < 2 {
 		regex := regexp.MustCompile(`(\/.+\/)((?:[0-9]{1,3}\.){3}[0-9]{1,3})(\%\d+)?(\:\d+)`)
 		destination := regex.FindStringSubmatch(vs.Destination)
 		parsedDestination := destination[2] + destination[3]
@@ -287,8 +287,8 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		}
 		if err := d.Set("destination", parsedDestination); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
-	    }
-       }
+		}
+	}
 	if err := d.Set("source", vs.Source); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Source to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
@@ -302,28 +302,28 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("[DEBUG] Error saving Mask to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 
-//	/* Service port is provided by the API in the destination attribute "/partition_name/virtual_server_address[%route_domain]:(port)"
-//	   so we need to extract it
-//	*/
-//	regex = regexp.MustCompile(`\:(\d+)`)
-//	port := regex.FindStringSubmatch(vs.Destination)
-//	if len(port) < 2 {
-//		return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
-//	}
-//	parsedPort, _ := strconv.Atoi(port[1])
+	//	/* Service port is provided by the API in the destination attribute "/partition_name/virtual_server_address[%route_domain]:(port)"
+	//	   so we need to extract it
+	//	*/
+	//	regex = regexp.MustCompile(`\:(\d+)`)
+	//	port := regex.FindStringSubmatch(vs.Destination)
+	//	if len(port) < 2 {
+	//		return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
+	//	}
+	//	parsedPort, _ := strconv.Atoi(port[1])
 
 	if strings.Count(vs_dest, ":") < 2 {
-	        regex := regexp.MustCompile(`\:(\d+)`)
-     	        port := regex.FindStringSubmatch(vs.Destination)
-                if len(port) < 2 {
-                  return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
-                }
-	      parsedPort, _ := strconv.Atoi(port[1])
-	      d.Set("port", parsedPort)
+		regex := regexp.MustCompile(`\:(\d+)`)
+		port := regex.FindStringSubmatch(vs.Destination)
+		if len(port) < 2 {
+			return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
+		}
+		parsedPort, _ := strconv.Atoi(port[1])
+		d.Set("port", parsedPort)
 	}
 	if strings.Count(vs_dest, ":") >= 2 {
-                regex := regexp.MustCompile(`^(\/.+\/)(.*:[^%]*)(?:\%\d+)?(?:\.(\d+))$`)
-                destination := regex.FindStringSubmatch(vs.Destination)
+		regex := regexp.MustCompile(`^(\/.+\/)(.*:[^%]*)(?:\%\d+)?(?:\.(\d+))$`)
+		destination := regex.FindStringSubmatch(vs.Destination)
 		parsedPort, _ := strconv.Atoi(destination[3])
 		d.Set("port", parsedPort)
 	}

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -324,7 +324,6 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 	if strings.Count(vs_dest, ":") >= 2 {
                 regex := regexp.MustCompile(`^(\/.+\/)(.*:[^%]*)(?:\%\d+)?(?:\.(\d+))$`)
                 destination := regex.FindStringSubmatch(vs.Destination)
-		log.Printf("port is :%s",destination[3])
 		parsedPort, _ := strconv.Atoi(destination[3])
 		d.Set("port", parsedPort)
 	}

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -45,7 +46,8 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 			"source": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "0.0.0.0/0",
+				//Default:     "0.0.0.0/0",
+				Computed:    true,
 				Description: "Source IP and mask for the virtual server",
 			},
 			"description": {
@@ -75,8 +77,9 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 			"mask": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "255.255.255.255",
-				Description: "Mask can either be in CIDR notation or decimal, i.e.: \"24\" or \"255.255.255.0\". A CIDR mask of \"0\" is the same as \"0.0.0.0\"",
+				//Default:     "255.255.255.255",
+				Computed:    true,
+				Description: "subnet mask",
 			},
 
 			"profiles": {
@@ -184,8 +187,35 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 	}
 }
 
+func resourceBigipLtmVirtualServerAttrDefaults(d *schema.ResourceData) {
+	_, hasMask := d.GetOk("mask")
+	_, hasSource := d.GetOk("source")
+
+	// Set default mask if nil
+	if !hasMask {
+		// looks like IPv6, lets set to /128
+		if strings.Contains(d.Get("destination").(string), ":") {
+			d.Set("mask", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+		} else { // /32 for IPv4
+			d.Set("mask", "255.255.255.255")
+		}
+	}
+
+	// set default source if nil
+	if !hasSource {
+		// looks like IPv6, lets set to ::/0
+		if strings.Contains(d.Get("destination").(string), ":") {
+			d.Set("source", "::/0")
+		} else { // 0.0.0.0/0
+			d.Set("source", "0.0.0.0/0")
+		}
+	}
+}
+
 func resourceBigipLtmVirtualServerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*bigip.BigIP)
+
+	resourceBigipLtmVirtualServerAttrDefaults(d)
 
 	name := d.Get("name").(string)
 	port := d.Get("port").(int)
@@ -236,21 +266,29 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		d.SetId("")
 		return nil
 	}
-	// Extract destination address from "/partition_name/(virtual_server_address)[%route_domain]:port"
-	regex := regexp.MustCompile(`(\/.+\/)((?:[0-9]{1,3}\.){3}[0-9]{1,3})(\%\d+)?(\:\d+)`)
-	destination := regex.FindStringSubmatch(vs.Destination)
-	parsedDestination := destination[2] + destination[3]
-	if len(destination) < 3 {
-		return fmt.Errorf("Unable to extract destination address from virtual server destination: " + vs.Destination)
-	}
-	if err := d.Set("destination", parsedDestination); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
-	}
 
-	// Extract source address from "(source_address)[%route_domain](/mask)" groups 1 + 2
-	//regex = regexp.MustCompile(`((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?(\/\d+)`)
-	//source := regex.FindStringSubmatch(vs.Source)
-	//parsedSource := source[1] + source[2]
+	vs_dest := vs.Destination
+	if strings.Count(vs_dest, ":") >= 2 {
+		regex := regexp.MustCompile(`^(\/.+\/)(.*:[^%]*)(?:\%\d+)?(?:\.(\d+))$`)
+                destination := regex.FindStringSubmatch(vs.Destination)
+                if destination == nil {
+                        return fmt.Errorf("Unable to extract destination address and port from virtual server destination: " + vs.Destination)
+                }
+		if err := d.Set("destination", destination[2]); err != nil {
+		       return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
+           }
+       }
+       if strings.Count(vs_dest, ":") < 2 {
+		regex := regexp.MustCompile(`(\/.+\/)((?:[0-9]{1,3}\.){3}[0-9]{1,3})(\%\d+)?(\:\d+)`)
+		destination := regex.FindStringSubmatch(vs.Destination)
+		parsedDestination := destination[2] + destination[3]
+		if len(destination) < 3 {
+			return fmt.Errorf("Unable to extract destination address from virtual server destination: " + vs.Destination)
+		}
+		if err := d.Set("destination", parsedDestination); err != nil {
+			return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
+	    }
+       }
 	if err := d.Set("source", vs.Source); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Source to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
@@ -264,17 +302,32 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("[DEBUG] Error saving Mask to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 
-	/* Service port is provided by the API in the destination attribute "/partition_name/virtual_server_address[%route_domain]:(port)"
-	   so we need to extract it
-	*/
-	regex = regexp.MustCompile(`\:(\d+)`)
-	port := regex.FindStringSubmatch(vs.Destination)
-	if len(port) < 2 {
-		return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
-	}
-	parsedPort, _ := strconv.Atoi(port[1])
-	d.Set("port", parsedPort)
+//	/* Service port is provided by the API in the destination attribute "/partition_name/virtual_server_address[%route_domain]:(port)"
+//	   so we need to extract it
+//	*/
+//	regex = regexp.MustCompile(`\:(\d+)`)
+//	port := regex.FindStringSubmatch(vs.Destination)
+//	if len(port) < 2 {
+//		return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
+//	}
+//	parsedPort, _ := strconv.Atoi(port[1])
 
+	if strings.Count(vs_dest, ":") < 2 {
+	        regex := regexp.MustCompile(`\:(\d+)`)
+     	        port := regex.FindStringSubmatch(vs.Destination)
+                if len(port) < 2 {
+                  return fmt.Errorf("Unable to extract service port from virtual server destination: %s", vs.Destination)
+                }
+	      parsedPort, _ := strconv.Atoi(port[1])
+	      d.Set("port", parsedPort)
+	}
+	if strings.Count(vs_dest, ":") >= 2 {
+                regex := regexp.MustCompile(`^(\/.+\/)(.*:[^%]*)(?:\%\d+)?(?:\.(\d+))$`)
+                destination := regex.FindStringSubmatch(vs.Destination)
+		log.Printf("port is :%s",destination[3])
+		parsedPort, _ := strconv.Atoi(destination[3])
+		d.Set("port", parsedPort)
+	}
 	d.Set("irules", makeStringList(&vs.Rules))
 	d.Set("ip_protocol", vs.IPProtocol)
 	d.Set("description", vs.Description)
@@ -366,6 +419,8 @@ func resourceBigipLtmVirtualServerExists(d *schema.ResourceData, meta interface{
 func resourceBigipLtmVirtualServerUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*bigip.BigIP)
 
+	resourceBigipLtmVirtualServerAttrDefaults(d)
+
 	name := d.Id()
 
 	var profiles []bigip.Profile
@@ -411,8 +466,13 @@ func resourceBigipLtmVirtualServerUpdate(d *schema.ResourceData, meta interface{
 		rules = listToStringSlice(cfg_rules.([]interface{}))
 	}
 
+	destPort := fmt.Sprintf("%s:%d", d.Get("destination").(string), d.Get("port").(int))
+	if strings.Contains(d.Get("destination").(string), ":") {
+		destPort = fmt.Sprintf("%s.%d", d.Get("destination").(string), d.Get("port").(int))
+	}
+
 	vs := &bigip.VirtualServer{
-		Destination:                fmt.Sprintf("%s:%d", d.Get("destination").(string), d.Get("port").(int)),
+		Destination:                destPort,
 		FallbackPersistenceProfile: d.Get("fallback_persistence_profile").(string),
 		Source:                     d.Get("source").(string),
 		Pool:                       d.Get("pool").(string),

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -76,8 +76,6 @@ resource "bigip_ltm_virtual_server" "test-vs" {
 }
 `
 
-
-
 func TestAccBigipLtmVS_create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -56,6 +56,27 @@ resource "bigip_ltm_virtual_server" "test-vs" {
 
 }
 `
+var TEST_VS6_NAME = fmt.Sprintf("/%s/test-vs6", TEST_PARTITION)
+
+var TEST_VS6_RESOURCE = TEST_IRULE_RESOURCE + `
+resource "bigip_ltm_virtual_server" "test-vs" {
+	name = "` + TEST_VS6_NAME + `"
+        destination = "fe80::11"
+	description = "VirtualServer-test"
+	port = 9999
+	source_address_translation = "automap"
+	ip_protocol = "tcp"
+	irules = ["${bigip_ltm_irule.test-rule.name}"]
+	profiles = ["/Common/http"]
+	client_profiles = ["/Common/tcp"]
+	server_profiles = ["/Common/tcp-lan-optimized"]
+	persistence_profiles = ["/Common/source_addr", "/Common/hash"]
+	default_persistence_profile = "/Common/hash"
+	fallback_persistence_profile = "/Common/dest_addr"
+}
+`
+
+
 
 func TestAccBigipLtmVS_create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -77,6 +98,47 @@ func TestAccBigipLtmVS_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "port", "9999"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "state", "enabled"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "mask", "255.255.255.255"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "source", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "source_address_translation", "automap"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "ip_protocol", "tcp"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "irules.0", TEST_IRULE_NAME),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
+						fmt.Sprintf("profiles.%d", schema.HashString("/Common/http")),
+						"/Common/http"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
+						fmt.Sprintf("client_profiles.%d", schema.HashString("/Common/tcp")),
+						"/Common/tcp"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
+						fmt.Sprintf("server_profiles.%d", schema.HashString("/Common/tcp-lan-optimized")),
+						"/Common/tcp-lan-optimized"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
+						fmt.Sprintf("persistence_profiles.%d", schema.HashString("/Common/source_addr")),
+						"/Common/source_addr"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "fallback_persistence_profile", "/Common/dest_addr"),
+				),
+			},
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckVSsDestroyed,
+			testCheckIRulesDestroyed,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_VS6_RESOURCE,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVSExists(TEST_VS6_NAME, true),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "name", TEST_VS6_NAME),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "destination", "fe80::11"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "port", "9999"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "mask", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "source", "::/0"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "description", "VirtualServer-test"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "source_address_translation", "automap"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "ip_protocol", "tcp"),
@@ -97,9 +159,9 @@ func TestAccBigipLtmVS_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
 						fmt.Sprintf("persistence_profiles.%d", schema.HashString("/Common/hash")),
 						"/Common/hash"),
-					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
-						fmt.Sprintf("policies.%d", schema.HashString("http_to_https_redirect")),
-						"http_to_https_redirect"),
+					//resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs",
+					//		fmt.Sprintf("policies.%d", schema.HashString("http_to_https_redirect")),
+					//	"http_to_https_redirect"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "fallback_persistence_profile", "/Common/dest_addr"),
 				),
 			},
@@ -240,6 +302,24 @@ func TestAccBigipLtmVS_import(t *testing.T) {
 					testCheckVSExists(TEST_VS_NAME, true),
 				),
 				ResourceName:      TEST_VS_NAME,
+				ImportState:       false,
+				ImportStateVerify: true,
+			},
+		},
+	})
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAcctPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckVSsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: TEST_VS6_RESOURCE,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckVSExists(TEST_VS6_NAME, true),
+				),
+				ResourceName:      TEST_VS6_NAME,
 				ImportState:       false,
 				ImportStateVerify: true,
 			},

--- a/bigip/validators.go
+++ b/bigip/validators.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-
+	"strings"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -56,9 +56,9 @@ func validateF5Name(value interface{}, field string) (ws []string, errors []erro
 	}
 
 	for _, v := range values {
-		match, _ := regexp.MatchString("^/[\\w_\\-.]+/[\\w_\\-.]+$", v)
+		match, _ := regexp.MatchString("^/[\\w_\\-.]+/[\\w_\\-.:]+$", v)
 		if !match {
-			errors = append(errors, fmt.Errorf("%q must match /Partition/Name and contain letters, numbers or [._-]. e.g. /Common/my-pool", field))
+			errors = append(errors, fmt.Errorf("%q must match /Partition/Name and contain letters, numbers or [._-:]. e.g. /Common/my-pool", field))
 		}
 	}
 	return
@@ -112,9 +112,17 @@ func validatePoolMemberName(value interface{}, field string) (ws []string, error
 	}
 
 	for _, v := range values {
+
+		if strings.Count(v, ":") >= 2  {
+			match, _ := regexp.MatchString("^\\/[\\w_\\-.]+\\/[\\w_\\-.:]+.\\d+$", v)
+			if !match {
+                            errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [:._-]. e.g. /Common/node1:80", field))
+	}
+		} else {
 		match, _ := regexp.MatchString("^\\/[\\w_\\-.]+\\/[\\w_\\-.]+:\\d+$", v)
 		if !match {
-			errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [._-]. e.g. /Common/node1:80", field))
+                        errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [._-]. e.g. /Common/node1:80", field))
+                  } 
 		}
 	}
 	return

--- a/bigip/validators.go
+++ b/bigip/validators.go
@@ -8,10 +8,10 @@ package bigip
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"reflect"
 	"regexp"
 	"strings"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 //Validate the incoming set only contains values from the specified set
@@ -113,16 +113,16 @@ func validatePoolMemberName(value interface{}, field string) (ws []string, error
 
 	for _, v := range values {
 
-		if strings.Count(v, ":") >= 2  {
+		if strings.Count(v, ":") >= 2 {
 			match, _ := regexp.MatchString("^\\/[\\w_\\-.]+\\/[\\w_\\-.:]+.\\d+$", v)
 			if !match {
-                            errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [:._-]. e.g. /Common/node1:80", field))
-	}
+				errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [:._-]. e.g. /Common/node1:80", field))
+			}
 		} else {
-		match, _ := regexp.MatchString("^\\/[\\w_\\-.]+\\/[\\w_\\-.]+:\\d+$", v)
-		if !match {
-                        errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [._-]. e.g. /Common/node1:80", field))
-                  } 
+			match, _ := regexp.MatchString("^\\/[\\w_\\-.]+\\/[\\w_\\-.]+:\\d+$", v)
+			if !match {
+				errors = append(errors, fmt.Errorf("%q must match /Partition/Node_Name:Port and contain letters, numbers or [._-]. e.g. /Common/node1:80", field))
+			}
 		}
 	}
 	return

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -2248,22 +2248,34 @@ func (b *BigIP) VirtualServers() (*VirtualServers, error) {
 // in CIDR notation or decimal, i.e.: "24" or "255.255.255.0". A CIDR mask of "0" is the same
 // as "0.0.0.0".
 func (b *BigIP) CreateVirtualServer(name, destination, mask, pool string, vlans_enabled bool, port int, translate_address, translate_port string) error {
-	subnetMask := cidr[mask]
 
-	if strings.Contains(mask, ".") {
-		subnetMask = mask
-	}
+	if strings.Contains(destination, ":") {
+                subnetMask := mask
 
+		config := &VirtualServer{
+                Name:             name,
+                Destination:      fmt.Sprintf("%s.%d", destination, port),
+                Mask:             subnetMask,
+                Pool:             pool,
+                TranslateAddress: translate_address,
+                TranslatePort:    translate_port,
+             }
+
+             return b.post(config, uriLtm, uriVirtual)
+        }
+
+        subnetMask := cidr[mask]
 	config := &VirtualServer{
-		Name:             name,
-		Destination:      fmt.Sprintf("%s:%d", destination, port),
-		Mask:             subnetMask,
-		Pool:             pool,
-		TranslateAddress: translate_address,
-		TranslatePort:    translate_port,
-	}
+                Name:             name,
+                Destination:      fmt.Sprintf("%s:%d", destination, port),
+                Mask:             subnetMask,
+                Pool:             pool,
+                TranslateAddress: translate_address,
+                TranslatePort:    translate_port,
+             }
 
-	return b.post(config, uriLtm, uriVirtual)
+          return b.post(config, uriLtm, uriVirtual)
+
 }
 
 // AddVirtualServer adds a new virtual server by config to the BIG-IP system.


### PR DESCRIPTION
Adding v6 node and virtual server in acceptance tests and ran it.

root@terraforn-ubuntu3:~/go/src/github.com/terraform-providers/terraform-provider-bigip# BIGIP_USER=xxxx BIGIP_PASSWORD=xxxx BIGIP_HOST=xxxxx TF_ACC=1 go test ./bigip -v -run=TestAccBigipLtmNode_create
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (8.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-bigip/bigip	8.441s
root@terraforn-ubuntu3:~/go/src/github.com/terraform-providers/terraform-provider-bigip# 


root@terraforn-ubuntu3:~/go/src/github.com/terraform-providers/terraform-provider-bigip# BIGIP_USER=xxxx BIGIP_PASSWORD=xxxx BIGIP_HOST=xxxxx TF_ACC=1 go test ./bigip -v -run=TestAccBigipLtmVS_create
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (9.35s)
=== RUN   TestAccBigipLtmVS_create_Defaultstate
--- PASS: TestAccBigipLtmVS_create_Defaultstate (4.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-bigip/bigip	13.578s
root@terraforn-ubuntu3:~/go/src/github.com/terraform-providers/terraform-provider-bigip# 



